### PR TITLE
fix(winhl): apply both Normal and FloatBorder overrides

### DIFF
--- a/lua/tui-nvim.lua
+++ b/lua/tui-nvim.lua
@@ -89,8 +89,7 @@ function M:new(opts)
     row      = dim.row
   })
 
-  vim.api.nvim_win_set_option(M.win, "winhl", ("Normal:%s"):format(opts.winhl))
-  vim.api.nvim_win_set_option(M.win, "winhl", ("FloatBorder:%s"):format(opts.borderhl))
+  vim.api.nvim_win_set_option(M.win, "winhl", ("Normal:%s,FloatBorder:%s"):format(opts.winhl, opts.borderhl))
   vim.api.nvim_win_set_option(M.win, "winblend", opts.winblend)
 
 	vim.api.nvim_buf_set_option(M.buf, "filetype", "TUI")


### PR DESCRIPTION
From the docs:
>	Window-local highlights.  Comma-delimited list of highlight
	|group-name| pairs "{hl-from}:{hl-to},..." where each {hl-from} is
	a |highlight-groups| item to be overridden by {hl-to} group in
	the window.

This change just sets the `Normal` and `FloatBorder` overrides in the same `nvim_win_set_option` call so that one doesn't override other.